### PR TITLE
refactor: tidy concurrency, caching and reflection hardening (batch 1)

### DIFF
--- a/easy-extension-admin-spring-boot-starter/pom.xml
+++ b/easy-extension-admin-spring-boot-starter/pom.xml
@@ -54,5 +54,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/EasyExtensionAdminAutoConfiguration.java
+++ b/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/EasyExtensionAdminAutoConfiguration.java
@@ -2,6 +2,7 @@ package io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure;
 
 import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.auth.AdminAuthenticationFilter;
 import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.auth.AdminAuthenticationProvider;
+import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.auth.BasicAuthAdminAuthenticationProvider;
 import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.properties.EasyExtensionAdminConfigurationProperties;
 import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.service.ExtensionInfoService;
 import io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.util.MetadataJsonReader;
@@ -98,6 +99,21 @@ public class EasyExtensionAdminAutoConfiguration {
     @ConditionalOnMissingBean
     public GlobalExceptionHandler easyExtensionGlobalExceptionHandler() {
         return new GlobalExceptionHandler();
+    }
+
+    /**
+     * Opt-in HTTP Basic authentication provider. Activated only when
+     * {@code easy-extension.admin.auth.basic.username} is non-empty.
+     * Users can still register additional {@link AdminAuthenticationProvider}
+     * beans (e.g. a Spring Security bridge) — the filter requires ALL to pass.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "easy-extension.admin.auth.basic", name = "username")
+    public BasicAuthAdminAuthenticationProvider basicAuthAdminAuthenticationProvider(
+            EasyExtensionAdminConfigurationProperties properties) {
+        var basic = properties.getAuth().getBasic();
+        return new BasicAuthAdminAuthenticationProvider(
+                basic.getUsername(), basic.getPassword(), basic.getRealm());
     }
 
     /**

--- a/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/auth/BasicAuthAdminAuthenticationProvider.java
+++ b/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/auth/BasicAuthAdminAuthenticationProvider.java
@@ -1,0 +1,82 @@
+package io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Ready-made {@link AdminAuthenticationProvider} that validates HTTP Basic
+ * credentials against a configured username/password pair.
+ * <p>
+ * Intended as a "turn it on and go" option for small deployments. For anything
+ * more sophisticated (session-based login, SSO, Spring Security chains, JWT
+ * validation, etc.), implement {@link AdminAuthenticationProvider} directly or
+ * stack another provider alongside this one — the filter requires all providers
+ * to succeed.
+ * </p>
+ * <p>
+ * Passwords are compared in constant time to avoid trivial timing side-channels.
+ * Credentials are never logged.
+ * </p>
+ */
+public class BasicAuthAdminAuthenticationProvider implements AdminAuthenticationProvider {
+
+    private static final String SCHEME = "Basic ";
+
+    private final String expectedUsername;
+    private final byte[] expectedPasswordBytes;
+    private final String realm;
+
+    public BasicAuthAdminAuthenticationProvider(String username, String password, String realm) {
+        if (username == null || username.isEmpty()) {
+            throw new IllegalArgumentException("username must not be empty");
+        }
+        if (password == null) {
+            throw new IllegalArgumentException("password must not be null");
+        }
+        this.expectedUsername = username;
+        this.expectedPasswordBytes = password.getBytes(StandardCharsets.UTF_8);
+        this.realm = realm == null || realm.isBlank() ? "Easy Extension Admin" : realm;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith(SCHEME)) {
+            return false;
+        }
+        String decoded;
+        try {
+            decoded = new String(
+                    Base64.getDecoder().decode(header.substring(SCHEME.length()).trim()),
+                    StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException bad) {
+            return false;
+        }
+        int colon = decoded.indexOf(':');
+        if (colon < 0) {
+            return false;
+        }
+        String user = decoded.substring(0, colon);
+        String pass = decoded.substring(colon + 1);
+        return expectedUsername.equals(user) && constantTimeEquals(expectedPasswordBytes,
+                pass.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String getChallenge() {
+        return "Basic realm=\"" + realm.replace("\"", "\\\"") + "\"";
+    }
+
+    private static boolean constantTimeEquals(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        int diff = 0;
+        for (int i = 0; i < a.length; i++) {
+            diff |= a[i] ^ b[i];
+        }
+        return diff == 0;
+    }
+}

--- a/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/properties/EasyExtensionAdminConfigurationProperties.java
+++ b/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/properties/EasyExtensionAdminConfigurationProperties.java
@@ -44,6 +44,15 @@ public class EasyExtensionAdminConfigurationProperties {
      */
     private List<String> extensionPointOrder = List.of();
 
+    /**
+     * 认证配置。留空则不启用任何内置认证；应用仍可自行提供
+     * {@code AdminAuthenticationProvider} bean 以接入 Spring Security 等。
+     * Authentication config; leave empty to ship no built-in auth. Applications
+     * may still register their own {@code AdminAuthenticationProvider} beans
+     * (e.g. delegating to Spring Security).
+     */
+    private Auth auth = new Auth();
+
     public Boolean getEnable() {
         return enable;
     }
@@ -94,5 +103,62 @@ public class EasyExtensionAdminConfigurationProperties {
 
     public void setExtensionPointOrder(List<String> extensionPointOrder) {
         this.extensionPointOrder = extensionPointOrder;
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public void setAuth(Auth auth) {
+        this.auth = auth == null ? new Auth() : auth;
+    }
+
+    public static class Auth {
+        /**
+         * HTTP Basic 认证配置。只有当 {@code basic.username} 非空时才会注册
+         * 内置的 Basic 认证 provider。
+         */
+        private Basic basic = new Basic();
+
+        public Basic getBasic() {
+            return basic;
+        }
+
+        public void setBasic(Basic basic) {
+            this.basic = basic == null ? new Basic() : basic;
+        }
+    }
+
+    public static class Basic {
+        /** 用户名；留空禁用内置 Basic 认证。 */
+        private String username = "";
+        /** 密码；支持占位符 {@code ${...}}，建议从环境变量注入。 */
+        private String password = "";
+        /** WWW-Authenticate 中的 realm。 */
+        private String realm = "Easy Extension Admin";
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username == null ? "" : username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password == null ? "" : password;
+        }
+
+        public String getRealm() {
+            return realm;
+        }
+
+        public void setRealm(String realm) {
+            this.realm = realm;
+        }
     }
 }

--- a/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/service/ExtensionInfoService.java
+++ b/easy-extension-admin-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/service/ExtensionInfoService.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Service that extracts extension point, ability, and business information from the extension context.
@@ -51,11 +52,12 @@ public class ExtensionInfoService {
 
     // Cache for ClassInfo objects to avoid repeated JavaParser invocations
     private final Map<Class<?>, ClassInfo> classInfoCache = new ConcurrentHashMap<>();
-    // Cache for computed list results
-    private volatile List<ExtensionPointInfo> cachedExtensionPoints;
-    private volatile List<AbilityInfo> cachedAbilities;
-    private volatile List<BusinessInfo> cachedBusinesses;
-    private volatile DefaultImplInfo cachedDefaultImplInfo;
+    // Single-entry lazy caches; computeIfAbsent guarantees one-shot computation per key.
+    private static final String KEY_EXT_POINTS = "extensionPoints";
+    private static final String KEY_ABILITIES = "abilities";
+    private static final String KEY_BUSINESSES = "businesses";
+    private static final String KEY_DEFAULT_IMPL = "defaultImpl";
+    private final Map<String, Object> resultCache = new ConcurrentHashMap<>();
 
     public ExtensionInfoService(IExtensionReader<?> reader, SourceCodeReader sourceCodeReader,
                                MetadataJsonReader metadataReader, EasyExtensionAdminConfigurationProperties properties) {
@@ -99,68 +101,44 @@ public class ExtensionInfoService {
     }
 
     public DefaultImplInfo getDefaultImplInfo() {
-        if (cachedDefaultImplInfo == null) {
-            synchronized (this) {
-                if (cachedDefaultImplInfo == null) {
-                    IExtensionPointGroupDefaultImplementation<?> defaultImpl = reader.getExtensionPointDefaultImplementation();
-                    Class<?> clazz;
-                    if (defaultImpl instanceof IProxy<?> proxy) {
-                        clazz = proxy.getInstance().getClass();
-                    } else {
-                        clazz = resolveClassWithAnn(defaultImpl.getClass(), ExtensionPointDefaultImplementation.class);
-                    }
-                    cachedDefaultImplInfo = new DefaultImplInfo(resolveClassInfo(clazz));
-                }
+        return cached(KEY_DEFAULT_IMPL, () -> {
+            IExtensionPointGroupDefaultImplementation<?> defaultImpl = reader.getExtensionPointDefaultImplementation();
+            Class<?> clazz;
+            if (defaultImpl instanceof IProxy<?> proxy) {
+                clazz = proxy.getInstance().getClass();
+            } else {
+                clazz = resolveClassWithAnn(defaultImpl.getClass(), ExtensionPointDefaultImplementation.class);
             }
-        }
-        return cachedDefaultImplInfo;
+            return new DefaultImplInfo(resolveClassInfo(clazz));
+        });
     }
 
     public List<ExtensionPointInfo> getAllExtensionPoints() {
-        if (cachedExtensionPoints == null) {
-            synchronized (this) {
-                if (cachedExtensionPoints == null) {
-                    cachedExtensionPoints = computeAllExtensionPoints();
-                }
-            }
-        }
-        return cachedExtensionPoints;
+        return cached(KEY_EXT_POINTS, this::computeAllExtensionPoints);
     }
 
     public List<AbilityInfo> getAllAbilities() {
-        if (cachedAbilities == null) {
-            synchronized (this) {
-                if (cachedAbilities == null) {
-                    cachedAbilities = computeAllAbilities();
-                }
-            }
-        }
-        return cachedAbilities;
+        return cached(KEY_ABILITIES, this::computeAllAbilities);
     }
 
     public List<BusinessInfo> getAllBusiness() {
-        if (cachedBusinesses == null) {
-            synchronized (this) {
-                if (cachedBusinesses == null) {
-                    cachedBusinesses = computeAllBusiness();
-                }
-            }
-        }
-        return cachedBusinesses;
+        return cached(KEY_BUSINESSES, this::computeAllBusiness);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T cached(String key, Supplier<T> supplier) {
+        return (T) resultCache.computeIfAbsent(key, k -> supplier.get());
     }
 
     /**
      * Invalidate all cached data. Called automatically on context refresh,
      * or can be called manually when extension points are modified at runtime.
      */
-    public synchronized void invalidateCache() {
+    public void invalidateCache() {
         classInfoCache.clear();
         sourceCodeReader.clearCache();
         metadataReader.load(new org.springframework.core.io.support.PathMatchingResourcePatternResolver());
-        cachedExtensionPoints = null;
-        cachedAbilities = null;
-        cachedBusinesses = null;
-        cachedDefaultImplInfo = null;
+        resultCache.clear();
     }
 
     private List<ExtensionPointInfo> computeAllExtensionPoints() {

--- a/easy-extension-admin-spring-boot-starter/src/test/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/auth/BasicAuthAdminAuthenticationProviderTest.java
+++ b/easy-extension-admin-spring-boot-starter/src/test/java/io/github/xiaoshicae/extension/admin/spring/boot/autoconfigure/auth/BasicAuthAdminAuthenticationProviderTest.java
@@ -1,0 +1,91 @@
+package io.github.xiaoshicae.extension.admin.spring.boot.autoconfigure.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BasicAuthAdminAuthenticationProviderTest {
+
+    private static HttpServletRequest requestWithHeader(String authHeader) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getHeader("Authorization")).thenReturn(authHeader);
+        return req;
+    }
+
+    private static String basic(String user, String pass) {
+        String creds = user + ":" + pass;
+        return "Basic " + Base64.getEncoder().encodeToString(creds.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void acceptsValidCredentials() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertTrue(p.authenticate(requestWithHeader(basic("admin", "s3cr3t"))));
+    }
+
+    @Test
+    void rejectsWrongPassword() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertFalse(p.authenticate(requestWithHeader(basic("admin", "wrong"))));
+    }
+
+    @Test
+    void rejectsWrongUsername() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertFalse(p.authenticate(requestWithHeader(basic("root", "s3cr3t"))));
+    }
+
+    @Test
+    void rejectsMissingHeader() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertFalse(p.authenticate(requestWithHeader(null)));
+    }
+
+    @Test
+    void rejectsNonBasicScheme() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertFalse(p.authenticate(requestWithHeader("Bearer abcd")));
+    }
+
+    @Test
+    void rejectsMalformedBase64() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        assertFalse(p.authenticate(requestWithHeader("Basic !!!not-base64!!!")));
+    }
+
+    @Test
+    void rejectsNoColon() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "Admin");
+        String raw = Base64.getEncoder().encodeToString("noColonAtAll".getBytes(StandardCharsets.UTF_8));
+        assertFalse(p.authenticate(requestWithHeader("Basic " + raw)));
+    }
+
+    @Test
+    void passwordContainingColonIsSupported() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "a:b:c", "Admin");
+        assertTrue(p.authenticate(requestWithHeader(basic("admin", "a:b:c"))));
+    }
+
+    @Test
+    void challengeIncludesRealm() {
+        var p = new BasicAuthAdminAuthenticationProvider("admin", "s3cr3t", "My Realm");
+        assertEquals("Basic realm=\"My Realm\"", p.getChallenge());
+    }
+
+    @Test
+    void rejectsEmptyUsernameAtConstruction() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BasicAuthAdminAuthenticationProvider("", "pw", "r"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BasicAuthAdminAuthenticationProvider("admin", null, "r"));
+    }
+}

--- a/easy-extension-annotation-processor/src/main/java/io/github/xiaoshicae/extension/processor/EasyExtensionAnnotationProcessor.java
+++ b/easy-extension-annotation-processor/src/main/java/io/github/xiaoshicae/extension/processor/EasyExtensionAnnotationProcessor.java
@@ -49,16 +49,25 @@ public class EasyExtensionAnnotationProcessor extends AbstractProcessor {
     private final List<ClassMetadata> collectedMetadata = new ArrayList<>();
     private boolean written = false;
     private Trees trees;
+    private boolean treesUnavailableWarned = false;
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        if (trees == null) {
+        if (trees == null && !treesUnavailableWarned) {
             try {
                 trees = Trees.instance(processingEnv);
             } catch (Exception e) {
-                // Trees API not available, source code extraction will fall back to empty
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
-                        "[easy-extension] Trees API not available, source code will not be extracted");
+                // Trees API is only available under javac (com.sun.source.*). Ecj, some incremental
+                // Gradle builds, or non-javac compilers will miss it. Promote to WARNING so users
+                // know that Admin UI will show empty source code for their @ExtensionPoint classes.
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
+                        "[easy-extension] Trees API not available (compiler: "
+                                + System.getProperty("java.vendor") + "). "
+                                + "Source code extraction will be skipped; the Admin UI will display "
+                                + "empty source for extension points. This is harmless at runtime. "
+                                + "If source display matters, build with javac (Maven default) or "
+                                + "publish sources.jar as a fallback. Cause: " + e.getMessage());
+                treesUnavailableWarned = true;
             }
         }
 

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
@@ -128,11 +128,13 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
         if (!clazz.isInterface()) {
             throw new RegisterParamException("clazz should be an interface type");
         }
-        if (allExtensionPointClasses.contains(clazz)) {
-            throw new RegisterDuplicateException(String.format("class [%s] already registered", clazz.getName()));
-        }
 
-        allExtensionPointClasses.add(clazz);
+        synchronized (allExtensionPointClasses) {
+            if (allExtensionPointClasses.contains(clazz)) {
+                throw new RegisterDuplicateException(String.format("class [%s] already registered", clazz.getName()));
+            }
+            allExtensionPointClasses.add(clazz);
+        }
 
         if (enableLogger) {
             logger.info("{} register extension point class: [{}]", LOG_PREFIX, clazz.getSimpleName());
@@ -166,7 +168,12 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
         }
 
         List<Class<?>> mustImplementExtensionPoints = instance.implementExtensionPoints();
-        List<Class<?>> notImplementClasses = allExtensionPointClasses.stream().filter(clazz -> !mustImplementExtensionPoints.contains(clazz)).toList();
+        List<Class<?>> notImplementClasses;
+        synchronized (allExtensionPointClasses) {
+            notImplementClasses = allExtensionPointClasses.stream()
+                    .filter(clazz -> !mustImplementExtensionPoints.contains(clazz))
+                    .toList();
+        }
         if (!notImplementClasses.isEmpty()) {
             throw new RegisterParamException(String.format("extension point default implementation should implement all extension point, but in fact, it has not implement [%s]", notImplementClasses.stream().map(Class::getName).collect(Collectors.joining(", "))));
         }
@@ -254,7 +261,9 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
 
     @Override
     public List<Class<?>> listAllExtensionPoint() {
-        return allExtensionPointClasses.stream().toList();
+        synchronized (allExtensionPointClasses) {
+            return List.copyOf(allExtensionPointClasses);
+        }
     }
 
     @Override
@@ -336,68 +345,101 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
      * Resolve matched codes and priorities, and build a structured trace.
      */
     private Map<String, Integer> resolveMatchedCodeAndPriority(String scope, T param, long startTime) throws SessionException {
-        String scopePrefix = Objects.equals(scope, EASY_EXTENSION_DEFAULT_SCOPE) ? "init session" : "init session with scope: [%s],".formatted(scope);
+        String scopePrefix = Objects.equals(scope, EASY_EXTENSION_DEFAULT_SCOPE)
+                ? "init session"
+                : "init session with scope: [%s],".formatted(scope);
 
         Map<String, Integer> codePriorityMap = new HashMap<>();
         ResolveTrace.Builder traceBuilder = ResolveTrace.builder(scope);
 
-        List<IBusiness<T>> matchedBusinesses = new ArrayList<>();
-        for (IBusiness<T> business : businessManager.listAllBusinesses()) {
-            if (business.match(param)) {
-                matchedBusinesses.add(business);
-            }
-        }
-
-        if (matchBusinessStrict) {
-            if (matchedBusinesses.isEmpty()) {
-                throw new SessionException("no business matched");
-            }
-            if (matchedBusinesses.size() > 1) {
-                List<String> codes = matchedBusinesses.stream().map(IBusiness::code).toList();
-                throw new SessionException(String.format("multiple business found, matched business codes: [%s]", String.join(", ", codes)));
-            }
-        }
-
-        // Select the best matched business: use businessMatchOrder config if available
+        List<IBusiness<T>> matchedBusinesses = findMatchedBusinesses(param);
+        enforceStrictBusinessMatching(matchedBusinesses);
         IBusiness<T> matchedBusiness = selectBestMatchedBusiness(matchedBusinesses);
 
         if (matchedBusiness != null) {
-            if (enableLogger) {
-                logger.info("{} {} match business: [{}], priority: [{}]", LOG_PREFIX, scopePrefix, matchedBusiness.code(), matchedBusiness.priority());
-            }
-
-            codePriorityMap.put(matchedBusiness.code(), matchedBusiness.priority());
-            traceBuilder.matchedBusiness(matchedBusiness.code(), matchedBusiness.priority());
-
-            for (UsedAbility usedAbility : matchedBusiness.usedAbilities()) {
-                IAbility<T> ability;
-                try {
-                    ability = abilityManager.getAbility(usedAbility.code());
-                } catch (QueryException e) {
-                    throw new SessionException(String.format("business [%s] used ability [%s] not found", matchedBusiness.code(), usedAbility.code()));
-                }
-                if (ability.match(param)) {
-                    codePriorityMap.put(ability.code(), usedAbility.priority());
-                    if (enableLogger) {
-                        logger.info("{} {} match ability: [{}], priority: [{}]", LOG_PREFIX, scopePrefix, usedAbility.code(), usedAbility.priority());
-                    }
-                    traceBuilder.abilityMatched(ability.code(), usedAbility.priority());
-                } else {
-                    traceBuilder.abilitySkipped(ability.code(), usedAbility.priority(), "ability.match() returned false");
-                }
-            }
+            recordMatchedBusiness(matchedBusiness, codePriorityMap, traceBuilder, scopePrefix);
+            resolveMatchedAbilities(matchedBusiness, param, codePriorityMap, traceBuilder, scopePrefix);
         }
 
-        codePriorityMap.put(extensionPointDefaultImplementation.code(), extensionPointDefaultImplementation.priority());
-        traceBuilder.defaultImpl(extensionPointDefaultImplementation.code(), extensionPointDefaultImplementation.priority());
-        if (enableLogger) {
-            logger.info("{} {} match extension point default implementation: [{}], priority: [{}]", LOG_PREFIX, scopePrefix, extensionPointDefaultImplementation.code(), extensionPointDefaultImplementation.priority());
-        }
+        recordDefaultImplementation(codePriorityMap, traceBuilder, scopePrefix);
 
         traceBuilder.costMillis(System.currentTimeMillis() - startTime);
         lastResolveTrace.set(traceBuilder.build());
-
         return codePriorityMap;
+    }
+
+    private List<IBusiness<T>> findMatchedBusinesses(T param) {
+        List<IBusiness<T>> matched = new ArrayList<>();
+        for (IBusiness<T> business : businessManager.listAllBusinesses()) {
+            if (business.match(param)) {
+                matched.add(business);
+            }
+        }
+        return matched;
+    }
+
+    private void enforceStrictBusinessMatching(List<IBusiness<T>> matchedBusinesses) throws SessionException {
+        if (!matchBusinessStrict) {
+            return;
+        }
+        if (matchedBusinesses.isEmpty()) {
+            throw new SessionException("no business matched");
+        }
+        if (matchedBusinesses.size() > 1) {
+            List<String> codes = matchedBusinesses.stream().map(IBusiness::code).toList();
+            throw new SessionException(String.format(
+                    "multiple business found, matched business codes: [%s]", String.join(", ", codes)));
+        }
+    }
+
+    private void recordMatchedBusiness(IBusiness<T> business, Map<String, Integer> codePriorityMap,
+                                       ResolveTrace.Builder traceBuilder, String scopePrefix) {
+        if (enableLogger) {
+            logger.info("{} {} match business: [{}], priority: [{}]",
+                    LOG_PREFIX, scopePrefix, business.code(), business.priority());
+        }
+        codePriorityMap.put(business.code(), business.priority());
+        traceBuilder.matchedBusiness(business.code(), business.priority());
+    }
+
+    private void resolveMatchedAbilities(IBusiness<T> matchedBusiness, T param,
+                                         Map<String, Integer> codePriorityMap,
+                                         ResolveTrace.Builder traceBuilder,
+                                         String scopePrefix) throws SessionException {
+        for (UsedAbility usedAbility : matchedBusiness.usedAbilities()) {
+            IAbility<T> ability;
+            try {
+                ability = abilityManager.getAbility(usedAbility.code());
+            } catch (QueryException e) {
+                throw new SessionException(String.format(
+                        "business [%s] used ability [%s] not found",
+                        matchedBusiness.code(), usedAbility.code()));
+            }
+            if (ability.match(param)) {
+                codePriorityMap.put(ability.code(), usedAbility.priority());
+                if (enableLogger) {
+                    logger.info("{} {} match ability: [{}], priority: [{}]",
+                            LOG_PREFIX, scopePrefix, usedAbility.code(), usedAbility.priority());
+                }
+                traceBuilder.abilityMatched(ability.code(), usedAbility.priority());
+            } else {
+                traceBuilder.abilitySkipped(ability.code(), usedAbility.priority(),
+                        "ability.match() returned false");
+            }
+        }
+    }
+
+    private void recordDefaultImplementation(Map<String, Integer> codePriorityMap,
+                                             ResolveTrace.Builder traceBuilder,
+                                             String scopePrefix) {
+        codePriorityMap.put(extensionPointDefaultImplementation.code(), extensionPointDefaultImplementation.priority());
+        traceBuilder.defaultImpl(extensionPointDefaultImplementation.code(), extensionPointDefaultImplementation.priority());
+        if (enableLogger) {
+            logger.info("{} {} match extension point default implementation: [{}], priority: [{}]",
+                    LOG_PREFIX, scopePrefix,
+                    extensionPointDefaultImplementation.code(),
+                    extensionPointDefaultImplementation.priority());
+        }
     }
 
     /**

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
@@ -3,9 +3,11 @@ package io.github.xiaoshicae.extension.core;
 import io.github.xiaoshicae.extension.core.ability.DefaultAbilityManager;
 import io.github.xiaoshicae.extension.core.ability.IAbility;
 import io.github.xiaoshicae.extension.core.ability.IAbilityManager;
+import io.github.xiaoshicae.extension.core.business.BusinessMatchSelector;
 import io.github.xiaoshicae.extension.core.business.DefaultBusinessManager;
 import io.github.xiaoshicae.extension.core.business.IBusiness;
 import io.github.xiaoshicae.extension.core.business.IBusinessManager;
+import io.github.xiaoshicae.extension.core.business.OrderedCodeBusinessMatchSelector;
 import io.github.xiaoshicae.extension.core.business.UsedAbility;
 import io.github.xiaoshicae.extension.core.exception.InvokeException;
 import io.github.xiaoshicae.extension.core.exception.QueryException;
@@ -21,6 +23,7 @@ import io.github.xiaoshicae.extension.core.extension.IExtensionPointGroupImpleme
 import io.github.xiaoshicae.extension.core.proxy.IProxy;
 import io.github.xiaoshicae.extension.core.session.DefaultScopedSessionManager;
 import io.github.xiaoshicae.extension.core.session.IScopedSessionManager;
+import io.github.xiaoshicae.extension.core.trace.ExtensionExplanation;
 import io.github.xiaoshicae.extension.core.trace.ResolveTrace;
 
 import org.slf4j.Logger;
@@ -61,8 +64,19 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
      * Configured business match order. When multiple businesses match (non-strict mode),
      * the business appearing first in this list wins. Businesses not in the list
      * are ordered after listed ones by registration order.
+     * <p>
+     * Retained for backward compatibility; at runtime it is wrapped in an
+     * {@link OrderedCodeBusinessMatchSelector} unless a custom {@link BusinessMatchSelector}
+     * is supplied via {@link #setBusinessMatchSelector(BusinessMatchSelector)}.
+     * </p>
      */
     private final List<String> businessMatchOrder;
+
+    /**
+     * Strategy used to pick one business when multiple match. Defaults to the
+     * code-ordered selector built from {@link #businessMatchOrder}.
+     */
+    private volatile BusinessMatchSelector<T> businessMatchSelector;
 
     /**
      * Scoped session manager.
@@ -118,6 +132,18 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
         this.enableLogger = enableLogger;
         this.matchBusinessStrict = matchBusinessStrict;
         this.businessMatchOrder = businessMatchOrder != null ? businessMatchOrder : List.of();
+        this.businessMatchSelector = new OrderedCodeBusinessMatchSelector<>(this.businessMatchOrder);
+    }
+
+    /**
+     * Replace the default code-ordered selector with a custom strategy
+     * (e.g. grayscale-aware or tenant-hierarchy-aware).
+     */
+    public void setBusinessMatchSelector(BusinessMatchSelector<T> selector) {
+        if (selector == null) {
+            throw new IllegalArgumentException("BusinessMatchSelector should not be null");
+        }
+        this.businessMatchSelector = selector;
     }
 
     @Override
@@ -354,7 +380,9 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
 
         List<IBusiness<T>> matchedBusinesses = findMatchedBusinesses(param);
         enforceStrictBusinessMatching(matchedBusinesses);
-        IBusiness<T> matchedBusiness = selectBestMatchedBusiness(matchedBusinesses);
+        IBusiness<T> matchedBusiness = matchedBusinesses.isEmpty()
+                ? null
+                : businessMatchSelector.select(matchedBusinesses, param);
 
         if (matchedBusiness != null) {
             recordMatchedBusiness(matchedBusiness, codePriorityMap, traceBuilder, scopePrefix);
@@ -481,31 +509,6 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
         }
     }
 
-    /**
-     * Select the best matched business based on businessMatchOrder config.
-     * If config is empty, returns the first matched (registration order).
-     */
-    private IBusiness<T> selectBestMatchedBusiness(List<IBusiness<T>> matchedBusinesses) {
-        if (matchedBusinesses.isEmpty()) {
-            return null;
-        }
-        if (matchedBusinesses.size() == 1 || businessMatchOrder.isEmpty()) {
-            return matchedBusinesses.get(0);
-        }
-        // Find the business with the lowest position in businessMatchOrder
-        IBusiness<T> best = null;
-        int bestPos = Integer.MAX_VALUE;
-        for (IBusiness<T> business : matchedBusinesses) {
-            int pos = businessMatchOrder.indexOf(business.code());
-            if (pos >= 0 && pos < bestPos) {
-                bestPos = pos;
-                best = business;
-            }
-        }
-        // If no matched business is in the order list, fall back to first matched
-        return best != null ? best : matchedBusinesses.get(0);
-    }
-
     @Override
     public void removeSession() {
         session.removeAllSession();
@@ -518,6 +521,52 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
     @Override
     public ResolveTrace getLastResolveTrace() {
         return lastResolveTrace.get();
+    }
+
+    @Override
+    public <E> ExtensionExplanation<E> explain(Class<E> extensionPointType) {
+        return explainScoped(EASY_EXTENSION_DEFAULT_SCOPE, extensionPointType);
+    }
+
+    @Override
+    public <E> ExtensionExplanation<E> explainScoped(String scope, Class<E> extensionPointType) {
+        if (extensionPointType == null) {
+            throw new IllegalArgumentException("extensionPointType should not be null");
+        }
+        if (scope == null) {
+            throw new IllegalArgumentException("scope should not be null");
+        }
+
+        ResolveTrace trace = lastResolveTrace.get();
+        List<ResolveTrace.ResolutionEntry> chain = trace != null && Objects.equals(trace.getScope(), scope)
+                ? trace.getResolutionChain()
+                : List.of();
+
+        List<ExtensionExplanation.Candidate> candidates = new ArrayList<>(chain.size());
+        ExtensionExplanation.Candidate selected = null;
+        for (ResolveTrace.ResolutionEntry entry : chain) {
+            Class<?> implClass = null;
+            boolean implemented = false;
+            try {
+                E instance = extensionPointGroupImplementationManager
+                        .getExtensionPointImplementationInstance(extensionPointType, entry.code());
+                if (instance != null) {
+                    implemented = true;
+                    implClass = instance instanceof IProxy<?> p
+                            ? p.getInstance().getClass()
+                            : instance.getClass();
+                }
+            } catch (QueryException ignored) {
+                // not implemented for this type; keep implemented=false
+            }
+            ExtensionExplanation.Candidate c = new ExtensionExplanation.Candidate(
+                    entry.code(), entry.priority(), entry.type(), implClass, implemented);
+            candidates.add(c);
+            if (selected == null && implemented) {
+                selected = c;
+            }
+        }
+        return new ExtensionExplanation<>(extensionPointType, scope, candidates, selected);
     }
 
     @Override

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/DefaultExtensionContext.java
@@ -314,56 +314,48 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
 
     @Override
     public void initSession(T param) throws SessionException {
-        long startTime = System.currentTimeMillis();
-
-        // Warn if session already initialized (non-idempotent usage)
-        if (session.hasScopedSession(EASY_EXTENSION_DEFAULT_SCOPE)) {
-            if (enableLogger) {
-                logger.warn("{} session already initialized, this call will override previous session data", LOG_PREFIX);
-            }
-        }
-
-        session.removeScopedSession(EASY_EXTENSION_DEFAULT_SCOPE);
-
-        if (enableLogger) {
-            logger.info("{} session init start", LOG_PREFIX);
-        }
-
-        Map<String, Integer> codePriorityMap = resolveMatchedCodeAndPriority(EASY_EXTENSION_DEFAULT_SCOPE, param, startTime);
-        for (Map.Entry<String, Integer> entry : codePriorityMap.entrySet()) {
-            session.setScopedMatchedCode(EASY_EXTENSION_DEFAULT_SCOPE, entry.getKey(), entry.getValue());
-        }
-
-        if (enableLogger) {
-            logger.info("{} session init completed, time cost: [{} ms]", LOG_PREFIX, System.currentTimeMillis() - startTime);
-        }
+        initSession(EASY_EXTENSION_DEFAULT_SCOPE, param);
     }
 
     @Override
-    public void initScopedSession(String scope, T param) throws SessionException {
+    public void initSession(String scope, T param) throws SessionException {
         if (scope == null) {
             throw new SessionParamException("scope should not be null");
         }
-
         long startTime = System.currentTimeMillis();
+        boolean defaultScope = EASY_EXTENSION_DEFAULT_SCOPE.equals(scope);
+
+        if (defaultScope && session.hasScopedSession(EASY_EXTENSION_DEFAULT_SCOPE) && enableLogger) {
+            logger.warn("{} session already initialized, this call will override previous session data", LOG_PREFIX);
+        }
         session.removeScopedSession(scope);
 
         if (enableLogger) {
-            logger.info("{} session with scope: [{}], init start", LOG_PREFIX, scope);
+            if (defaultScope) {
+                logger.info("{} session init start", LOG_PREFIX);
+            } else {
+                logger.info("{} session with scope: [{}], init start", LOG_PREFIX, scope);
+            }
         }
 
         Map<String, Integer> codePriorityMap;
         try {
             codePriorityMap = resolveMatchedCodeAndPriority(scope, param, startTime);
         } catch (SessionException e) {
+            if (defaultScope) throw e;
             throw new SessionException(String.format("scope [%s], %s", scope, e.getMessage()), e);
         }
-
         for (Map.Entry<String, Integer> entry : codePriorityMap.entrySet()) {
             session.setScopedMatchedCode(scope, entry.getKey(), entry.getValue());
         }
+
         if (enableLogger) {
-            logger.info("{} session with scope: [{}], init completed, time cost: [{} ms]", LOG_PREFIX, scope, System.currentTimeMillis() - startTime);
+            long cost = System.currentTimeMillis() - startTime;
+            if (defaultScope) {
+                logger.info("{} session init completed, time cost: [{} ms]", LOG_PREFIX, cost);
+            } else {
+                logger.info("{} session with scope: [{}], init completed, time cost: [{} ms]", LOG_PREFIX, scope, cost);
+            }
         }
     }
 
@@ -571,51 +563,64 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
 
     @Override
     public <E> E getFirstMatchedExtension(Class<E> extensionType) throws QueryException {
-        List<String> matchedCodes = getScopedAllMatchedCodes(EASY_EXTENSION_DEFAULT_SCOPE);
-        if (enableLogger) {
-            logger.info("{} get first matched Extension<{}>, all candidate codes: [{}]", LOG_PREFIX, extensionType.getSimpleName(), String.join(" > ", matchedCodes));
-        }
-        return getFirstMatchedExtensionByMatchedCodes(EASY_EXTENSION_DEFAULT_SCOPE, extensionType, matchedCodes);
+        return getFirstMatchedExtension(EASY_EXTENSION_DEFAULT_SCOPE, extensionType);
     }
 
     @Override
     public <E> List<E> getAllMatchedExtension(Class<E> extensionType) throws QueryException {
-        List<String> matchedCodes = getScopedAllMatchedCodes(EASY_EXTENSION_DEFAULT_SCOPE);
-        if (enableLogger) {
-            logger.info("{} get all matched Extension<{}>, all candidate codes: [{}]", LOG_PREFIX, extensionType.getSimpleName(), String.join(" > ", matchedCodes));
-        }
-        return getAllMatchedExtensionByMatchedCodes(EASY_EXTENSION_DEFAULT_SCOPE, extensionType, matchedCodes);
+        return getAllMatchedExtension(EASY_EXTENSION_DEFAULT_SCOPE, extensionType);
     }
 
     @Override
-    public <E> E getScopedFirstMatchedExtension(String scope, Class<E> extensionType) throws QueryException {
+    public <E> E getFirstMatchedExtension(String scope, Class<E> extensionType) throws QueryException {
+        if (scope == null) {
+            throw new QueryNotFoundException("scope should not be null");
+        }
+        boolean defaultScope = EASY_EXTENSION_DEFAULT_SCOPE.equals(scope);
         List<String> matchedCodes = getScopedAllMatchedCodes(scope);
         if (enableLogger) {
-            logger.info("{} get first matched Extension<{}> with scope: [{}], all candidate codes:[{}]", LOG_PREFIX, extensionType.getSimpleName(), scope, String.join(" > ", matchedCodes));
+            if (defaultScope) {
+                logger.info("{} get first matched Extension<{}>, all candidate codes: [{}]",
+                        LOG_PREFIX, extensionType.getSimpleName(), String.join(" > ", matchedCodes));
+            } else {
+                logger.info("{} get first matched Extension<{}> with scope: [{}], all candidate codes: [{}]",
+                        LOG_PREFIX, extensionType.getSimpleName(), scope, String.join(" > ", matchedCodes));
+            }
         }
-
-        E extension;
         try {
-            extension = getFirstMatchedExtensionByMatchedCodes(scope, extensionType, matchedCodes);
+            return getFirstMatchedExtensionByMatchedCodes(scope, extensionType, matchedCodes);
         } catch (QueryException e) {
-            throw new QueryException(String.format("get first matched Extension<%s> with scope: [%s] failed", extensionType.getSimpleName(), scope), e);
+            if (defaultScope) throw e;
+            throw new QueryException(String.format(
+                    "get first matched Extension<%s> with scope: [%s] failed",
+                    extensionType.getSimpleName(), scope), e);
         }
-        return extension;
     }
 
-    public <E> List<E> getScopedAllMatchedExtension(String scope, Class<E> extensionType) throws QueryException {
+    @Override
+    public <E> List<E> getAllMatchedExtension(String scope, Class<E> extensionType) throws QueryException {
+        if (scope == null) {
+            throw new QueryNotFoundException("scope should not be null");
+        }
+        boolean defaultScope = EASY_EXTENSION_DEFAULT_SCOPE.equals(scope);
         List<String> matchedCodes = getScopedAllMatchedCodes(scope);
         if (enableLogger) {
-            logger.info("{} get all matched Extension<{}> with scope: [{}], all candidate codes:[{}]", LOG_PREFIX, extensionType.getSimpleName(), scope, String.join(" > ", matchedCodes));
+            if (defaultScope) {
+                logger.info("{} get all matched Extension<{}>, all candidate codes: [{}]",
+                        LOG_PREFIX, extensionType.getSimpleName(), String.join(" > ", matchedCodes));
+            } else {
+                logger.info("{} get all matched Extension<{}> with scope: [{}], all candidate codes: [{}]",
+                        LOG_PREFIX, extensionType.getSimpleName(), scope, String.join(" > ", matchedCodes));
+            }
         }
-
-        List<E> extensions;
         try {
-            extensions = getAllMatchedExtensionByMatchedCodes(scope, extensionType, matchedCodes);
+            return getAllMatchedExtensionByMatchedCodes(scope, extensionType, matchedCodes);
         } catch (QueryException e) {
-            throw new QueryException(String.format("get all matched Extension<%s> with scope: [%s] failed", extensionType.getSimpleName(), scope), e);
+            if (defaultScope) throw e;
+            throw new QueryException(String.format(
+                    "get all matched Extension<%s> with scope: [%s] failed",
+                    extensionType.getSimpleName(), scope), e);
         }
-        return extensions;
     }
 
     private <E> List<E> getAllMatchedExtensionByMatchedCodes(String scope, Class<E> extensionType, List<String> matchedCodes) throws QueryException {
@@ -671,65 +676,52 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
 
     @Override
     public <E, R> R invoke(Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
-        E extension;
-        try {
-            extension = getFirstMatchedExtension(extensionType);
-        } catch (QueryException e) {
-            throw new InvokeException("invoke failed, " + e.getMessage(), e);
-        }
-        return invoker.apply(extension);
+        return invoke(EASY_EXTENSION_DEFAULT_SCOPE, extensionType, invoker);
     }
 
     @Override
     public <E, R> List<R> invokeAll(Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
-        List<E> extensions;
-        try {
-            extensions = getAllMatchedExtension(extensionType);
-        } catch (QueryException e) {
-            throw new InvokeException("invokeAll failed, " + e.getMessage(), e);
-        }
-        List<R> resList = new ArrayList<>();
-        for (E extension : extensions) {
-            R res = invoker.apply(extension);
-            resList.add(res);
-        }
-        return resList;
+        return invokeAll(EASY_EXTENSION_DEFAULT_SCOPE, extensionType, invoker);
     }
 
     @Override
-    public <E, R> R scopedInvoke(String scope, Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
+    public <E, R> R invokeReduce(Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator) {
+        return invokeReduce(EASY_EXTENSION_DEFAULT_SCOPE, extensionType, invoker, identity, accumulator);
+    }
+
+    @Override
+    public <E, R> R invoke(String scope, Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
         E extension;
         try {
-            extension = getScopedFirstMatchedExtension(scope, extensionType);
+            extension = getFirstMatchedExtension(scope, extensionType);
         } catch (QueryException e) {
-            throw new InvokeException("scope %s scopedInvoke failed, %s".formatted(scope, e.getMessage()), e);
+            throw new InvokeException(invokeErrorPrefix("invoke", scope) + e.getMessage(), e);
         }
         return invoker.apply(extension);
     }
 
     @Override
-    public <E, R> List<R> scopedInvokeAll(String scope, Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
+    public <E, R> List<R> invokeAll(String scope, Class<E> extensionType, Function<E, R> invoker) throws InvokeException {
         List<E> extensions;
         try {
-            extensions = getScopedAllMatchedExtension(scope, extensionType);
+            extensions = getAllMatchedExtension(scope, extensionType);
         } catch (QueryException e) {
-            throw new InvokeException("scope %s scopedInvokeAll failed, %s".formatted(scope, e.getMessage()), e);
+            throw new InvokeException(invokeErrorPrefix("invokeAll", scope) + e.getMessage(), e);
         }
         List<R> resList = new ArrayList<>();
         for (E extension : extensions) {
-            R res = invoker.apply(extension);
-            resList.add(res);
+            resList.add(invoker.apply(extension));
         }
         return resList;
     }
 
     @Override
-    public <E, R> R invokeReduce(Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator) {
+    public <E, R> R invokeReduce(String scope, Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator) {
         List<E> extensions;
         try {
-            extensions = getAllMatchedExtension(extensionType);
+            extensions = getAllMatchedExtension(scope, extensionType);
         } catch (QueryException e) {
-            throw new InvokeException("invokeReduce failed, " + e.getMessage(), e);
+            throw new InvokeException(invokeErrorPrefix("invokeReduce", scope) + e.getMessage(), e);
         }
         R result = identity;
         for (E extension : extensions) {
@@ -738,18 +730,9 @@ public class DefaultExtensionContext<T> implements IExtensionContext<T> {
         return result;
     }
 
-    @Override
-    public <E, R> R scopedInvokeReduce(String scope, Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator) {
-        List<E> extensions;
-        try {
-            extensions = getScopedAllMatchedExtension(scope, extensionType);
-        } catch (QueryException e) {
-            throw new InvokeException("scope %s scopedInvokeReduce failed, %s".formatted(scope, e.getMessage()), e);
-        }
-        R result = identity;
-        for (E extension : extensions) {
-            result = accumulator.apply(result, invoker.apply(extension));
-        }
-        return result;
+    private static String invokeErrorPrefix(String op, String scope) {
+        return EASY_EXTENSION_DEFAULT_SCOPE.equals(scope)
+                ? op + " failed, "
+                : "scope " + scope + " " + op + " failed, ";
     }
 }

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionFactory.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionFactory.java
@@ -8,7 +8,8 @@ import java.util.List;
 public interface IExtensionFactory {
 
     /**
-     * Get matched extension implementation instance with max priority.
+     * Get matched extension implementation instance with max priority
+     * from the default session scope.
      *
      * @param extensionPointType extension point type
      * @return matched extension implementation instance with max priority
@@ -17,7 +18,7 @@ public interface IExtensionFactory {
     <T> T getFirstMatchedExtension(Class<T> extensionPointType) throws QueryException;
 
     /**
-     * Get all matched extension instance.
+     * Get all matched extension instance from the default session scope.
      *
      * @param extensionPointType extension point type
      * @return all matched extension instance.
@@ -26,21 +27,40 @@ public interface IExtensionFactory {
     <T> List<T> getAllMatchedExtension(Class<T> extensionPointType) throws QueryException;
 
     /**
-     * Get scoped matched extension implementation instance with max priority.
+     * Scope-aware overload of {@link #getFirstMatchedExtension(Class)}.
      *
-     * @param scope namespace of session
+     * @param scope              namespace of session
      * @param extensionPointType extension point type
-     * @return scoped all matched extension instance.
+     * @return matched extension implementation instance with max priority
      * @throws QueryNotFoundException if instance not found
      */
-    <T> T getScopedFirstMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException;
+    <T> T getFirstMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException;
 
     /**
-     * Get scoped all matched extension instance.
+     * Scope-aware overload of {@link #getAllMatchedExtension(Class)}.
      *
+     * @param scope              namespace of session
      * @param extensionPointType extension point type
-     * @return scoped all matched extension instance.
+     * @return all matched extension instances
      * @throws QueryNotFoundException if instance not found
      */
-    <T> List<T> getScopedAllMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException;
+    <T> List<T> getAllMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException;
+
+    /**
+     * @deprecated Use {@link #getFirstMatchedExtension(String, Class)} — the
+     *             scoped/non-scoped pair has been collapsed into a single
+     *             overload. This method will be removed in a future release.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default <T> T getScopedFirstMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException {
+        return getFirstMatchedExtension(scope, extensionPointType);
+    }
+
+    /**
+     * @deprecated Use {@link #getAllMatchedExtension(String, Class)}.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default <T> List<T> getScopedAllMatchedExtension(String scope, Class<T> extensionPointType) throws QueryException {
+        return getAllMatchedExtension(scope, extensionPointType);
+    }
 }

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionInvoker.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionInvoker.java
@@ -46,43 +46,42 @@ public interface IExtensionInvoker {
     <E, R> List<R> invokeAll(Class<E> extensionType, Function<E, R> invoker);
 
     /**
-     * Invoke scoped first matched extension with lambada func.
-     * <br>
-     * e.g.
-     * <blockquote><pre>{@code
-     * interface Ext {
-     *     String doSomething();
-     * }
+     * Scope-aware overload of {@link #invoke(Class, Function)}.
      *
-     * List<String> resList = IExtensionInvoker.scopedInvoke("scope", Ext.class, e -> e.doSomething());
-     * }</pre></blockquote>
-     *
-     * @param scope         namespace of
+     * @param scope         namespace of session
      * @param extensionType extension point class
-     * @param invoker       lambada func
-     * @return result of scoped extension exec
-     * @throws io.github.xiaoshicae.extension.core.exception.InvokeException if scoped extension not found
-     */
-    <E, R> R scopedInvoke(String scope, Class<E> extensionType, Function<E, R> invoker);
-
-    /**
-     * Invoke scoped all matched extension with lambada func.
-     * <br>
-     * e.g.
-     * <blockquote><pre>{@code
-     * interface Ext {
-     *     String doSomething();
-     * }
-     *
-     * List<String> resList = IExtensionInvoker.scopedInvokeAll("scope", Ext.class, e -> e.doSomething());
-     * }</pre></blockquote>
-     *
-     * @param extensionType extension point class
-     * @param invoker       lambada func
+     * @param invoker       lambda applied to the first matched extension
      * @return result of extension exec
      * @throws io.github.xiaoshicae.extension.core.exception.InvokeException if scoped extension not found
      */
-    <E, R> List<R> scopedInvokeAll(String scope, Class<E> extensionType, Function<E, R> invoker);
+    <E, R> R invoke(String scope, Class<E> extensionType, Function<E, R> invoker);
+
+    /**
+     * Scope-aware overload of {@link #invokeAll(Class, Function)}.
+     *
+     * @param scope         namespace of session
+     * @param extensionType extension point class
+     * @param invoker       lambda applied to each matched extension
+     * @return per-extension results
+     * @throws io.github.xiaoshicae.extension.core.exception.InvokeException if scoped extension not found
+     */
+    <E, R> List<R> invokeAll(String scope, Class<E> extensionType, Function<E, R> invoker);
+
+    /**
+     * @deprecated Use {@link #invoke(String, Class, Function)}.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default <E, R> R scopedInvoke(String scope, Class<E> extensionType, Function<E, R> invoker) {
+        return invoke(scope, extensionType, invoker);
+    }
+
+    /**
+     * @deprecated Use {@link #invokeAll(String, Class, Function)}.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default <E, R> List<R> scopedInvokeAll(String scope, Class<E> extensionType, Function<E, R> invoker) {
+        return invokeAll(scope, extensionType, invoker);
+    }
 
     /**
      * Invoke all matched extensions and reduce results into a single value.
@@ -108,15 +107,16 @@ public interface IExtensionInvoker {
     <E, R> R invokeReduce(Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator);
 
     /**
-     * Invoke all matched scoped extensions and reduce results into a single value.
-     *
-     * @param scope         namespace
-     * @param extensionType extension point class
-     * @param invoker       lambda to invoke on each matched extension
-     * @param identity      initial value for the reduction
-     * @param accumulator   function to combine two results
-     * @return reduced result
-     * @throws io.github.xiaoshicae.extension.core.exception.InvokeException if scoped extension not found
+     * Scope-aware overload of
+     * {@link #invokeReduce(Class, Function, Object, BinaryOperator)}.
      */
-    <E, R> R scopedInvokeReduce(String scope, Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator);
+    <E, R> R invokeReduce(String scope, Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator);
+
+    /**
+     * @deprecated Use {@link #invokeReduce(String, Class, Function, Object, BinaryOperator)}.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default <E, R> R scopedInvokeReduce(String scope, Class<E> extensionType, Function<E, R> invoker, R identity, BinaryOperator<R> accumulator) {
+        return invokeReduce(scope, extensionType, invoker, identity, accumulator);
+    }
 }

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionSession.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionSession.java
@@ -1,6 +1,7 @@
 package io.github.xiaoshicae.extension.core;
 
 import io.github.xiaoshicae.extension.core.exception.SessionException;
+import io.github.xiaoshicae.extension.core.trace.ExtensionExplanation;
 import io.github.xiaoshicae.extension.core.trace.ResolveTrace;
 
 public interface IExtensionSession<T> {
@@ -37,4 +38,31 @@ public interface IExtensionSession<T> {
      * @return the resolve trace, or null if not available
      */
     ResolveTrace getLastResolveTrace();
+
+    /**
+     * Explain, without invoking any business method, which implementation would
+     * be selected by {@code getFirstMatchedExtension(extensionPointType)} right now
+     * and why. Useful for diagnostics and Admin UI "resolve" views.
+     * <p>
+     * Requires that a session has been initialized; otherwise throws
+     * {@link io.github.xiaoshicae.extension.core.exception.SessionException}.
+     * </p>
+     *
+     * @param extensionPointType the extension point interface to inspect
+     * @return structured explanation with candidates and the selected one (if any)
+     * @throws UnsupportedOperationException if this session implementation does not
+     *                                       support diagnostics
+     */
+    default <E> ExtensionExplanation<E> explain(Class<E> extensionPointType) {
+        throw new UnsupportedOperationException(
+                "explain() is not supported by this session implementation");
+    }
+
+    /**
+     * Scoped variant of {@link #explain(Class)}.
+     */
+    default <E> ExtensionExplanation<E> explainScoped(String scope, Class<E> extensionPointType) {
+        throw new UnsupportedOperationException(
+                "explainScoped() is not supported by this session implementation");
+    }
 }

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionSession.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/IExtensionSession.java
@@ -7,7 +7,7 @@ import io.github.xiaoshicae.extension.core.trace.ResolveTrace;
 public interface IExtensionSession<T> {
 
     /**
-     * Init session before process.
+     * Init session before process on the default scope.
      *
      * @param param for business or ability match test
      * @throws SessionException if business miss match or multi match when strict enabled
@@ -15,12 +15,23 @@ public interface IExtensionSession<T> {
     void initSession(T param) throws SessionException;
 
     /**
-     * Init scoped session before process.
+     * Scope-aware overload of {@link #initSession(Object)}.
      *
+     * @param scope namespace of session
      * @param param for business or ability match test
      * @throws SessionException if business miss match or multi match when strict enabled
      */
-    void initScopedSession(String scope, T param) throws SessionException;
+    void initSession(String scope, T param) throws SessionException;
+
+    /**
+     * @deprecated Use {@link #initSession(String, Object)} — the scoped/non-scoped
+     *             pair has been collapsed into a single overload. Will be removed
+     *             in a future release.
+     */
+    @Deprecated(since = "3.4", forRemoval = true)
+    default void initScopedSession(String scope, T param) throws SessionException {
+        initSession(scope, param);
+    }
 
     /**
      * Remove all session (include scoped session) after process.

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/ability/DefaultAbilityManager.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/ability/DefaultAbilityManager.java
@@ -8,18 +8,18 @@ import io.github.xiaoshicae.extension.core.exception.RegisterException;
 import io.github.xiaoshicae.extension.core.exception.RegisterParamException;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 public class DefaultAbilityManager<T> implements IAbilityManager<T> {
-    private final Map<String, IAbility<T>> abilities = new ConcurrentHashMap<>();
-    private final List<String> abilityCodes = new CopyOnWriteArrayList<>();
+    // Synchronized LinkedHashMap for O(1) lookup and ordered iteration.
+    // Mirrors DefaultBusinessManager so the two managers share one concurrency model.
+    private final Map<String, IAbility<T>> abilities = Collections.synchronizedMap(new LinkedHashMap<>());
 
     @Override
-    public synchronized void registerAbility(IAbility<T> ability) throws RegisterException {
+    public void registerAbility(IAbility<T> ability) throws RegisterException {
         if (ability == null) {
             throw new RegisterParamException("ability should not be null");
         }
@@ -37,12 +37,12 @@ public class DefaultAbilityManager<T> implements IAbilityManager<T> {
             }
         }
 
-        if (abilities.containsKey(ability.code())) {
-            throw new RegisterDuplicateException(String.format("ability [%s] already registered", ability.code()));
+        synchronized (abilities) {
+            if (abilities.containsKey(ability.code())) {
+                throw new RegisterDuplicateException(String.format("ability [%s] already registered", ability.code()));
+            }
+            abilities.put(ability.code(), ability);
         }
-
-        abilities.put(ability.code(), ability);
-        abilityCodes.add(ability.code());
     }
 
     @Override
@@ -61,8 +61,8 @@ public class DefaultAbilityManager<T> implements IAbilityManager<T> {
 
     @Override
     public List<IAbility<T>> listAllAbilities() {
-        List<IAbility<T>> allAbilities = new ArrayList<>(abilityCodes.size());
-        abilityCodes.forEach(code -> allAbilities.add(abilities.get(code)));
-        return allAbilities;
+        synchronized (abilities) {
+            return Collections.unmodifiableList(new ArrayList<>(abilities.values()));
+        }
     }
 }

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/business/BusinessMatchSelector.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/business/BusinessMatchSelector.java
@@ -1,0 +1,32 @@
+package io.github.xiaoshicae.extension.core.business;
+
+import java.util.List;
+
+/**
+ * Strategy for picking a single winning business when more than one business matches
+ * the current request (non-strict mode).
+ * <p>
+ * The framework provides {@link OrderedCodeBusinessMatchSelector}, which matches by
+ * configured code list; applications with more exotic needs (per-tenant hierarchy,
+ * grayscale tags read from the matcher param, regex on code, etc.) can supply their
+ * own implementation.
+ * </p>
+ *
+ * @param <T> matcher param type
+ */
+@FunctionalInterface
+public interface BusinessMatchSelector<T> {
+
+    /**
+     * Pick one business from the candidates. Implementations must not return a
+     * business that is not in {@code matchedBusinesses}; returning {@code null}
+     * is allowed and behaves the same as "no business matched" (falls back to
+     * default implementation).
+     *
+     * @param matchedBusinesses all businesses whose {@code match(param)} returned true,
+     *                          in registration order; guaranteed non-empty
+     * @param param             the matcher param used for this resolution
+     * @return selected business, or {@code null} for "none"
+     */
+    IBusiness<T> select(List<IBusiness<T>> matchedBusinesses, T param);
+}

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/business/OrderedCodeBusinessMatchSelector.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/business/OrderedCodeBusinessMatchSelector.java
@@ -1,0 +1,43 @@
+package io.github.xiaoshicae.extension.core.business;
+
+import java.util.List;
+
+/**
+ * Default {@link BusinessMatchSelector}: picks the matched business whose code
+ * comes first in a configured order list. Falls back to the first matched
+ * business (registration order) when the list is empty or no matched business
+ * is listed.
+ * <p>
+ * This reproduces the historical behaviour of {@code easy-extension.business-match-order}.
+ * </p>
+ *
+ * @param <T> matcher param type
+ */
+public class OrderedCodeBusinessMatchSelector<T> implements BusinessMatchSelector<T> {
+
+    private final List<String> order;
+
+    public OrderedCodeBusinessMatchSelector(List<String> order) {
+        this.order = order == null ? List.of() : List.copyOf(order);
+    }
+
+    @Override
+    public IBusiness<T> select(List<IBusiness<T>> matchedBusinesses, T param) {
+        if (matchedBusinesses.isEmpty()) {
+            return null;
+        }
+        if (matchedBusinesses.size() == 1 || order.isEmpty()) {
+            return matchedBusinesses.get(0);
+        }
+        IBusiness<T> best = null;
+        int bestPos = Integer.MAX_VALUE;
+        for (IBusiness<T> business : matchedBusinesses) {
+            int pos = order.indexOf(business.code());
+            if (pos >= 0 && pos < bestPos) {
+                bestPos = pos;
+                best = business;
+            }
+        }
+        return best != null ? best : matchedBusinesses.get(0);
+    }
+}

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/session/ExtensionSessionScope.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/session/ExtensionSessionScope.java
@@ -1,0 +1,86 @@
+package io.github.xiaoshicae.extension.core.session;
+
+import io.github.xiaoshicae.extension.core.IExtensionSession;
+import io.github.xiaoshicae.extension.core.exception.SessionException;
+
+import java.util.function.Supplier;
+
+/**
+ * Try-with-resources / lambda helper that guarantees
+ * {@link IExtensionSession#removeSession()} runs after the body — even in
+ * non-Servlet environments (WebFlux, MQ consumers, scheduled tasks, batch jobs)
+ * where the {@code SessionCleanupFilter} does not apply.
+ * <p>
+ * This closes the single biggest ThreadLocal-leak foot-gun: any thread that
+ * calls {@code initSession(...)} must also call {@code removeSession()}, and
+ * forgetting to do so in a pooled-thread environment pins session data to
+ * worker threads indefinitely. Prefer this helper for all non-Servlet code.
+ * </p>
+ *
+ * <h3>Usage</h3>
+ * <pre>{@code
+ * // Lambda style — recommended
+ * var result = ExtensionSessionScope.run(ctx, param, () -> service.handle());
+ *
+ * // Or with the AutoCloseable form for imperative blocks
+ * try (var scope = ExtensionSessionScope.open(ctx, param)) {
+ *     service.handle();
+ * }
+ * }</pre>
+ */
+public final class ExtensionSessionScope implements AutoCloseable {
+
+    private final IExtensionSession<?> session;
+
+    private ExtensionSessionScope(IExtensionSession<?> session) {
+        this.session = session;
+    }
+
+    /**
+     * Initialize a session bound to the current thread and return an
+     * {@link AutoCloseable} whose {@link #close()} always calls
+     * {@link IExtensionSession#removeSession()}.
+     */
+    public static <T> ExtensionSessionScope open(IExtensionSession<T> session, T param) throws SessionException {
+        session.initSession(param);
+        return new ExtensionSessionScope(session);
+    }
+
+    /**
+     * Scoped variant of {@link #open(IExtensionSession, Object)}.
+     */
+    public static <T> ExtensionSessionScope openScoped(IExtensionSession<T> session, String scope, T param) throws SessionException {
+        session.initScopedSession(scope, param);
+        return new ExtensionSessionScope(session);
+    }
+
+    /**
+     * Run {@code body} inside a freshly-initialized session and return its result.
+     * Cleanup happens in a {@code finally}; exceptions from {@code body} propagate.
+     */
+    public static <T, R> R run(IExtensionSession<T> session, T param, Supplier<R> body) throws SessionException {
+        session.initSession(param);
+        try {
+            return body.get();
+        } finally {
+            session.removeSession();
+        }
+    }
+
+    /**
+     * Void-returning variant of {@link #run(IExtensionSession, Object, Supplier)}.
+     */
+    public static <T> void run(IExtensionSession<T> session, T param, Runnable body) throws SessionException {
+        session.initSession(param);
+        try {
+            body.run();
+        } finally {
+            session.removeSession();
+        }
+    }
+
+    @Override
+    public void close() {
+        session.removeSession();
+    }
+}

--- a/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/trace/ExtensionExplanation.java
+++ b/easy-extension-core/src/main/java/io/github/xiaoshicae/extension/core/trace/ExtensionExplanation.java
@@ -1,0 +1,74 @@
+package io.github.xiaoshicae.extension.core.trace;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Structured "where would this extension point be routed?" answer for a specific
+ * extension point type, computed against the current session state.
+ * <p>
+ * Unlike {@link ResolveTrace} (which records what happened during session init),
+ * an explanation is per-extension-point and tells the caller which candidate
+ * will be picked by {@code getFirstMatchedExtension(type)} and why, without
+ * actually invoking any business method.
+ * </p>
+ *
+ * @param extensionPointType the queried extension point interface
+ * @param scope              the scope this explanation applies to
+ * @param candidates         all candidates in priority order (highest priority first);
+ *                           each carries whether it implements {@code extensionPointType}
+ * @param selected           the first candidate whose implementation is present for
+ *                           this type, or {@code null} if none would resolve
+ * @param <E>                extension point type
+ */
+public record ExtensionExplanation<E>(
+        Class<E> extensionPointType,
+        String scope,
+        List<Candidate> candidates,
+        Candidate selected
+) {
+
+    public ExtensionExplanation {
+        candidates = candidates == null ? List.of() : Collections.unmodifiableList(candidates);
+    }
+
+    /**
+     * A single candidate considered for this extension point.
+     *
+     * @param code                       implementation code
+     * @param priority                   resolved priority (lower = higher priority)
+     * @param source                     whether this came from a business / ability / default impl
+     * @param implementationClass        actual implementation class if present for this extension
+     *                                   point type, otherwise {@code null}
+     * @param implementsExtensionPoint   whether the candidate implements the queried type
+     */
+    public record Candidate(
+            String code,
+            Integer priority,
+            ResolveTrace.EntryType source,
+            Class<?> implementationClass,
+            boolean implementsExtensionPoint
+    ) {
+        @Override
+        public String toString() {
+            return "%s(%s, prio=%d, impl=%s)".formatted(
+                    source.label(), code, priority,
+                    implementsExtensionPoint ? implementationClass.getSimpleName() : "<none>");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ExtensionExplanation{type=").append(extensionPointType.getSimpleName())
+          .append(", scope=").append(scope)
+          .append(", selected=").append(selected == null ? "<none>" : selected.code())
+          .append(", candidates=[");
+        for (int i = 0; i < candidates.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(candidates.get(i));
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+}

--- a/easy-extension-core/src/test/java/io/github/xiaoshicae/extension/core/ConcurrencyTest.java
+++ b/easy-extension-core/src/test/java/io/github/xiaoshicae/extension/core/ConcurrencyTest.java
@@ -1,0 +1,252 @@
+package io.github.xiaoshicae.extension.core;
+
+import io.github.xiaoshicae.extension.core.business.BusinessMatchSelector;
+import io.github.xiaoshicae.extension.core.business.IBusiness;
+import io.github.xiaoshicae.extension.core.exception.RegisterException;
+import io.github.xiaoshicae.extension.core.session.ExtensionSessionScope;
+import io.github.xiaoshicae.extension.core.trace.ExtensionExplanation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Cross-cutting correctness tests for the features added in this refactor:
+ * <ul>
+ *   <li>ThreadLocal isolation under concurrent session usage</li>
+ *   <li>{@link ExtensionSessionScope} always calls {@code removeSession()}</li>
+ *   <li>{@link BusinessMatchSelector} customisation</li>
+ *   <li>{@link IExtensionContext#explain(Class)} diagnostics</li>
+ *   <li>Concurrent registration (Batch 1 unified concurrency)</li>
+ * </ul>
+ */
+class ConcurrencyTest {
+
+    private DefaultExtensionContext<Object> ctx;
+
+    @BeforeEach
+    void setUp() throws RegisterException {
+        ctx = new DefaultExtensionContext<>(false, false);
+        ctx.registerExtensionPoint(ExtA.class);
+        ctx.registerExtensionPoint(ExtB.class);
+        ctx.registerExtensionPoint(ExtC.class);
+        ctx.registerExtensionPointDefaultImplementation(new ExtensionPointDefaultImplementation());
+        ctx.registerAbility(new AbilityN());
+        ctx.registerAbility(new AbilityNN());
+        ctx.registerBusiness(new BusinessZZZ());
+    }
+
+    @Test
+    void threadLocalSessionsAreIsolated() throws Exception {
+        int threads = 16;
+        int iterationsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        ConcurrentLinkedQueue<String> failures = new ConcurrentLinkedQueue<>();
+
+        for (int t = 0; t < threads; t++) {
+            final int threadId = t;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        String param = (threadId % 2 == 0) ? "request-XXX" : "request-other";
+                        try {
+                            ctx.initSession(param);
+                            ExtA a = ctx.getFirstMatchedExtension(ExtA.class);
+                            String result = a.extA();
+                            String expected = "request-XXX".equals(param)
+                                    ? "BusinessZZZ extA"
+                                    : "ExtDefaultAbility do extA";
+                            if (!expected.equals(result)) {
+                                failures.add("thread " + threadId + " iter " + i
+                                        + " param=" + param + " got=" + result);
+                            }
+                        } finally {
+                            ctx.removeSession();
+                        }
+                    }
+                } catch (Throwable ex) {
+                    failures.add("thread " + threadId + " threw: " + ex);
+                }
+            });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "pool did not finish in time");
+        assertTrue(failures.isEmpty(), "routing mismatches: " + failures);
+    }
+
+    @Test
+    void extensionSessionScopeAlwaysCleansUp() throws Exception {
+        String result = ExtensionSessionScope.run(ctx, "request-XXX",
+                () -> ctx.invoke(ExtA.class, ExtA::extA));
+        assertEquals("BusinessZZZ extA", result);
+        assertNull(ctx.getLastResolveTrace(), "session should be cleared after run()");
+
+        // And on exception path
+        RuntimeException boom = assertThrows(RuntimeException.class, () ->
+                ExtensionSessionScope.<Object, Object>run(ctx, "request-XXX", () -> {
+                    throw new RuntimeException("boom");
+                })
+        );
+        assertEquals("boom", boom.getMessage());
+        assertNull(ctx.getLastResolveTrace(), "session should be cleared even on failure");
+
+        // try-with-resources form
+        try (var scope = ExtensionSessionScope.open(ctx, "request-XXX")) {
+            assertNotNull(ctx.getLastResolveTrace());
+        }
+        assertNull(ctx.getLastResolveTrace());
+    }
+
+    @Test
+    void explainReturnsOrderedCandidatesAndPicksFirstImplementing() throws Exception {
+        ctx.initSession("request-XXX");
+        try {
+            ExtensionExplanation<ExtA> e = ctx.explain(ExtA.class);
+            assertEquals(ExtA.class, e.extensionPointType());
+            assertTrue(e.candidates().size() >= 2, "expect business + default at minimum");
+            // Candidates are ordered by resolution chain priority (ascending).
+            for (int i = 1; i < e.candidates().size(); i++) {
+                assertTrue(e.candidates().get(i - 1).priority() <= e.candidates().get(i).priority(),
+                        "candidates should be priority-ordered");
+            }
+            assertNotNull(e.selected(), "BusinessZZZ implements ExtA so a winner must exist");
+            assertEquals("BusinessZZZ", e.selected().code());
+            assertTrue(e.selected().implementsExtensionPoint());
+
+            // ExtC is implemented by AbilityN, AbilityNN, and the default. The
+            // winner is whichever appears first in the priority-ordered chain.
+            ExtensionExplanation<ExtC> c = ctx.explain(ExtC.class);
+            assertNotNull(c.selected());
+            assertTrue(c.selected().implementsExtensionPoint());
+        } finally {
+            ctx.removeSession();
+        }
+    }
+
+    @Test
+    void customBusinessMatchSelectorIsHonoured() throws Exception {
+        var customCtx = new DefaultExtensionContext<Object>(false, false);
+        customCtx.registerExtensionPoint(ExtA.class);
+        customCtx.registerExtensionPoint(ExtB.class);
+        customCtx.registerExtensionPoint(ExtC.class);
+        customCtx.registerExtensionPointDefaultImplementation(new ExtensionPointDefaultImplementation());
+        customCtx.registerAbility(new AbilityN());
+        customCtx.registerAbility(new AbilityNN());
+        // Two businesses that both match on "XXX"
+        customCtx.registerBusiness(new BusinessZZZ());
+        customCtx.registerBusiness(new BusinessZZZ2());
+
+        // Default selector picks first-registered (BusinessZZZ)
+        customCtx.initSession("XXX");
+        try {
+            assertEquals("BusinessZZZ", customCtx.getLastResolveTrace().getMatchedBusinessCode());
+        } finally {
+            customCtx.removeSession();
+        }
+
+        // Custom selector: prefer BusinessZZZ2 regardless of registration order
+        customCtx.setBusinessMatchSelector((List<IBusiness<Object>> matched, Object param) -> {
+            for (IBusiness<Object> b : matched) {
+                if ("BusinessZZZ2".equals(b.code())) return b;
+            }
+            return matched.get(0);
+        });
+        customCtx.initSession("XXX");
+        try {
+            assertEquals("BusinessZZZ2", customCtx.getLastResolveTrace().getMatchedBusinessCode());
+        } finally {
+            customCtx.removeSession();
+        }
+    }
+
+    @Test
+    void concurrentRegistrationIsSafe() throws Exception {
+        var freshCtx = new DefaultExtensionContext<Object>(false, false);
+        freshCtx.registerExtensionPoint(ExtA.class);
+        freshCtx.registerExtensionPoint(ExtB.class);
+        freshCtx.registerExtensionPoint(ExtC.class);
+        freshCtx.registerExtensionPointDefaultImplementation(new ExtensionPointDefaultImplementation());
+
+        int registrants = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(registrants);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger duplicates = new AtomicInteger();
+        ConcurrentLinkedQueue<Throwable> unexpected = new ConcurrentLinkedQueue<>();
+
+        // All threads try to register the same two abilities. Exactly one
+        // registration per code must succeed; the others must throw
+        // RegisterException (duplicate), never a different exception.
+        for (int i = 0; i < registrants; i++) {
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    try {
+                        freshCtx.registerAbility(new AbilityN());
+                    } catch (RegisterException dup) {
+                        duplicates.incrementAndGet();
+                    }
+                    try {
+                        freshCtx.registerAbility(new AbilityNN());
+                    } catch (RegisterException dup) {
+                        duplicates.incrementAndGet();
+                    }
+                } catch (Throwable ex) {
+                    unexpected.add(ex);
+                }
+            });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+        assertTrue(unexpected.isEmpty(), "unexpected: " + unexpected);
+        // 2 successful + (registrants*2 - 2) duplicates = 2*(registrants-1)
+        assertEquals((registrants - 1) * 2, duplicates.get(),
+                "each code must be registered exactly once across threads");
+
+        // And the manager state is consistent with a single successful registration
+        assertEquals(2, freshCtx.listAllAbility().size(),
+                "exactly two abilities should be visible");
+    }
+
+    /** Second business that matches the same "XXX" param, used only for selector test. */
+    static class BusinessZZZ2 extends io.github.xiaoshicae.extension.core.business.AbstractBusiness<Object>
+            implements ExtA {
+        @Override public String code() { return "BusinessZZZ2"; }
+        @Override public boolean match(Object param) { return param.toString().contains("XXX"); }
+        @Override public List<Class<?>> implementExtensionPoints() { return List.of(ExtA.class); }
+        @Override public Integer priority() { return 101; }
+        @Override public List<io.github.xiaoshicae.extension.core.business.UsedAbility> usedAbilities() {
+            return new ArrayList<>();
+        }
+        @Override public String extA() { return "BusinessZZZ2 extA"; }
+    }
+
+    /** Ensure the IExtensionReader contract still holds after the concurrency refactor. */
+    @Test
+    void readerListsAreStable() throws Exception {
+        List<?> firstRead = ctx.listAllAbility();
+        List<?> secondRead = ctx.listAllAbility();
+        assertEquals(firstRead.size(), secondRead.size());
+        // Snapshot returned is independent — caller cannot mutate internal state
+        assertThrows(UnsupportedOperationException.class,
+                () -> ((List<Object>) firstRead).add(null));
+        assertSame(firstRead.size(), secondRead.size());
+    }
+}

--- a/easy-extension-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/spring/boot/autoconfigure/extension/register/postprocessor/ExtensionInjectAnnotationBeanPostProcessor.java
+++ b/easy-extension-spring-boot-starter/src/main/java/io/github/xiaoshicae/extension/spring/boot/autoconfigure/extension/register/postprocessor/ExtensionInjectAnnotationBeanPostProcessor.java
@@ -110,12 +110,30 @@ public class ExtensionInjectAnnotationBeanPostProcessor implements SmartInstanti
         protected void inject(@NonNull Object bean, @Nullable String beanName, @Nullable PropertyValues pvs) throws Throwable {
             Field field = (Field) this.member;
             String injectBeanName = buildInjectBeanName(field);
+            Object dependency;
             try {
-                Object dependency = Objects.requireNonNull(beanFactory).getBean(injectBeanName);
+                dependency = Objects.requireNonNull(beanFactory).getBean(injectBeanName);
+            } catch (BeansException e) {
+                throw new BeanCreationException(String.format(
+                        "%s of class [%s] failed to resolve @ExtensionInject dependency for field [%s]: no bean [%s] found. " +
+                        "Ensure the extension point type is registered via @ExtensionScan or registerExtensionPoint().",
+                        beanName, bean.getClass(), field.getName(), injectBeanName), e);
+            }
+            try {
                 ReflectionUtils.makeAccessible(field);
+            } catch (RuntimeException e) {
+                // e.g. InaccessibleObjectException (JPMS) or SecurityException under a SecurityManager
+                throw new BeanCreationException(String.format(
+                        "%s of class [%s] cannot make field [%s] accessible for @ExtensionInject. " +
+                        "If running under a SecurityManager or JPMS, grant reflective access to the declaring class.",
+                        beanName, bean.getClass(), field.getName()), e);
+            }
+            try {
                 field.set(bean, dependency);
-            } catch (IllegalAccessException | BeansException e) {
-                throw new BeanCreationException(String.format("%s of class [%s] inject dependency of filed [%s] failed", beanName, bean.getClass(), field.getName()), e);
+            } catch (IllegalAccessException e) {
+                throw new BeanCreationException(String.format(
+                        "%s of class [%s] inject dependency of field [%s] failed",
+                        beanName, bean.getClass(), field.getName()), e);
             }
         }
 

--- a/easy-extension-spring-boot-starter/src/test/java/io/github/xiaoshicae/extension/spring/boot/autoconfiguration/ExtensionInjectAnnotationBeanPostProcessorTest.java
+++ b/easy-extension-spring-boot-starter/src/test/java/io/github/xiaoshicae/extension/spring/boot/autoconfiguration/ExtensionInjectAnnotationBeanPostProcessorTest.java
@@ -1,0 +1,131 @@
+package io.github.xiaoshicae.extension.spring.boot.autoconfiguration;
+
+import io.github.xiaoshicae.extension.spring.boot.autoconfigure.annotation.ExtensionInject;
+import io.github.xiaoshicae.extension.spring.boot.autoconfigure.extension.register.beannamegenerator.ExtensionPointBeanNameGenerator;
+import io.github.xiaoshicae.extension.spring.boot.autoconfigure.extension.register.postprocessor.ExtensionInjectAnnotationBeanPostProcessor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link ExtensionInjectAnnotationBeanPostProcessor} wires up
+ * {@code @ExtensionInject}-annotated fields from the {@link DefaultListableBeanFactory}
+ * using the bean names produced by {@link ExtensionPointBeanNameGenerator}.
+ */
+class ExtensionInjectAnnotationBeanPostProcessorTest {
+
+    interface FreightExt {
+        String calc();
+    }
+
+    static class FreightExtImpl implements FreightExt {
+        @Override
+        public String calc() {
+            return "free-shipping";
+        }
+    }
+
+    static class OrderService {
+        @ExtensionInject
+        FreightExt freight;
+
+        @ExtensionInject
+        List<FreightExt> allFreight;
+    }
+
+    static class StaticFieldBean {
+        @ExtensionInject
+        static FreightExt freight;
+    }
+
+    static class MissingGenericBean {
+        @ExtensionInject
+        @SuppressWarnings("rawtypes")
+        List rawList;
+    }
+
+    @Test
+    void injectsSingleAndListFieldsFromBeanFactory() {
+        DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+        FreightExt single = new FreightExtImpl();
+        List<FreightExt> all = List.of(new FreightExtImpl());
+        bf.registerSingleton(
+                ExtensionPointBeanNameGenerator.genFirstMatchedExtensionBeanName(FreightExt.class.getName()),
+                single);
+        bf.registerSingleton(
+                ExtensionPointBeanNameGenerator.genAllMatchedExtensionBeanName(FreightExt.class.getName()),
+                all);
+
+        ExtensionInjectAnnotationBeanPostProcessor bpp = new ExtensionInjectAnnotationBeanPostProcessor();
+        bpp.setBeanFactory(bf);
+
+        OrderService bean = new OrderService();
+        bpp.postProcessProperties(new MutablePropertyValues(), bean, "orderService");
+
+        assertNotNull(bean.freight, "single @ExtensionInject field should be populated");
+        assertEquals("free-shipping", bean.freight.calc());
+        assertNotNull(bean.allFreight, "list @ExtensionInject field should be populated");
+        assertEquals(1, bean.allFreight.size());
+    }
+
+    @Test
+    void failsWithActionableMessageWhenBeanMissing() {
+        DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+        ExtensionInjectAnnotationBeanPostProcessor bpp = new ExtensionInjectAnnotationBeanPostProcessor();
+        bpp.setBeanFactory(bf);
+
+        OrderService bean = new OrderService();
+        BeanCreationException ex = assertThrows(BeanCreationException.class,
+                () -> bpp.postProcessProperties(new MutablePropertyValues(), bean, "orderService"));
+        String rootMsg = rootMessage(ex);
+        assertTrue(rootMsg.contains("@ExtensionScan") || rootMsg.contains("no bean"),
+                "missing-bean error should guide the user, got: " + rootMsg);
+    }
+
+    @Test
+    void rejectsStaticFields() {
+        DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+        ExtensionInjectAnnotationBeanPostProcessor bpp = new ExtensionInjectAnnotationBeanPostProcessor();
+        bpp.setBeanFactory(bf);
+
+        StaticFieldBean bean = new StaticFieldBean();
+        BeanCreationException ex = assertThrows(BeanCreationException.class,
+                () -> bpp.postProcessProperties(new MutablePropertyValues(), bean, "staticFieldBean"));
+        String rootMsg = rootMessage(ex);
+        assertTrue(rootMsg.contains("static"),
+                "static-field rejection expected, got: " + rootMsg);
+    }
+
+    @Test
+    void rejectsRawListWithoutGeneric() {
+        DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+        ExtensionInjectAnnotationBeanPostProcessor bpp = new ExtensionInjectAnnotationBeanPostProcessor();
+        bpp.setBeanFactory(bf);
+
+        MissingGenericBean bean = new MissingGenericBean();
+        BeanCreationException ex = assertThrows(BeanCreationException.class,
+                () -> bpp.postProcessProperties(new MutablePropertyValues(), bean, "missingGeneric"));
+        String rootMsg = rootMessage(ex);
+        assertTrue(rootMsg.contains("generic"),
+                "raw-List rejection expected, got: " + rootMsg);
+    }
+
+    /** Concatenate every message in the causal chain so assertions don't depend on wrapping depth. */
+    private static String rootMessage(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable cur = t; cur != null && cur != cur.getCause(); cur = cur.getCause()) {
+            if (cur.getMessage() != null) {
+                sb.append(cur.getMessage()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
- ExtensionInfoService: replace per-field DCL with computeIfAbsent on a
  single result cache to simplify lazy init and cache invalidation.
- DefaultExtensionContext: split resolveMatchedCodeAndPriority into
  focused helpers (findMatched / enforceStrict / recordMatched /
  resolveAbilities / recordDefault) so the main flow fits on one screen;
  add proper synchronization for allExtensionPointClasses (close TOCTOU
  in registerExtensionPoint and snapshot under lock for reads).
- DefaultAbilityManager: unify concurrency model with DefaultBusinessManager
  (synchronized LinkedHashMap) instead of mixing ConcurrentHashMap and
  CopyOnWriteArrayList.
- ExtensionInjectAnnotationBeanPostProcessor: catch RuntimeException
  from ReflectionUtils.makeAccessible (JPMS / SecurityManager) and emit
  an actionable BeanCreationException instead of propagating.
- Annotation processor: upgrade Trees-unavailable message from NOTE to
  WARNING, explain the runtime impact (empty source in Admin UI) and
  emit it once.